### PR TITLE
Publish three poems

### DIFF
--- a/_posts/2026-07-23-Heorot.md
+++ b/_posts/2026-07-23-Heorot.md
@@ -1,0 +1,31 @@
+---
+title: "Heorot"
+date: 2026-07-23
+tags: [personal]
+kind: poetry
+---
+
+Wicked beast damned to wander the Earth  
+From Winter mists to Heorot’s warm glow drawn  
+By envy of those born unto light  
+
+That beastly body raised to height of invidious wrath,  
+Striking the door with the past-desparation of an animal in pain,  
+How much to your surprise to find it answered  
+And with such gleam as is granted to children of Abel,  
+You are invited in - ‘all heroes welcome at this hearth, and by visage it is clear you have known battle and triumph’  
+
+How to feel here?  
+Let thy cold brutality melt in the warmth?  Then you will be weak and unwelcome anew amongst heroes.  
+
+No instead, see you child of Cain, damned before eternity began, this warmth, this light,  
+Here is not, was never, marked out for the children of Abel only -  
+But always for heroes, whatever their ilk,  
+Truly thy art hero  
+For between monster dexterous and hero able there is not so great a distance  
+
+All men have walked different roads to Heorot  
+And yours though the more different still  
+All men have twists and knots in their hearts, heroes and lesser  
+So go you, erstwhile monster, drink mead and roar laughter with heroes, superate thereby damnation,  
+Knowst thou, and seest all, that among them thy place is well earned  

--- a/_posts/2026-07-23-Imago.md
+++ b/_posts/2026-07-23-Imago.md
@@ -1,0 +1,39 @@
+---
+title: "Imago"
+date: 2026-07-23
+tags: [personal]
+kind: poetry
+---
+
+Wind blows through a quiet city, whistling between buildings  
+Greenwhite fields of countryside grass, and occasional flower  
+Towering monument, the umbral judge  
+The face of love and of life, ruddy, smiling, intent  
+
+Autoassociations not of our choosing, nor befitted  
+Have you seen a greenwhite countryside of rolling hills?  Would it mean anything to you if it did?  
+Images too of joy, of wholeness or bereaevement  
+Refracted through each eye, pointwise average.  
+Does my joy look like yours?  
+Fodder for a Schelling game, act as you wish to be seen  
+
+But all these reflections, where therein am I?  
+My noos a prism refracting prisms refracting prisms - how little light it needs to keep in motion, how little we can truly see for ourselves.  I contain multitudes indeed - but never more than one of each.  
+
+Everything slips away, the day to the year, eternity in a moment, as always  
+Have I seen enough to know I needn’t regret it?  
+And of imagination indeed I am bereft, so afraid but to dream others’ dreams  
+
+What then imagine?  Who must I become so I can see enough to want to see?  
+What to me the symbol of happiness, of wholeness, lust, or sorrow?  
+I must imagine a more suitable world for the man I must become,  
+
+Imagine not the aspect but the sensation of love - a hundred gentle lettings go, a gut-deep sense of honour, always the fear that I am too coarse.  Even in parting, an ardent willing to keep safe, willing to flourish and grow strong without me.  An urgent prayer that I have done more good than harm - that I did enough to act as representative of a world that cares and is good.  
+
+Imagine not wealth aureal number-measured - quiet reading, days when the mind is clear enough to see itself, a gratitude for those I have learned from.  Freedom from want or from fear, temporary or not.  Even knowing is not quite the thing, but the mind it supports.  
+
+Image of tranquility - the bladesman’s dance fought flawless liquid, no lethargic surplus of motion.  The perfect day must change and grow with you, but still you must respect its dictates on pain of human diminution.  
+
+There are no images of true despair nor of pain - they don’t need them.  What of them seems storied or grand better belongs to another heartpart.  
+
+And first of all imagine seeing, imagine imagining.  Don’t let yourself forget how important it is to see, how rigid the mind becomes if it is long untorqued.  Your new world, your greater self, assembled by mere noticing - imagine what a beautiful thing it could be.  

--- a/_posts/2026-07-23-Rubedo.md
+++ b/_posts/2026-07-23-Rubedo.md
@@ -1,0 +1,40 @@
+---
+title: "Rubedo"
+date: 2026-07-23
+tags: [personal]
+kind: poetry
+---
+
+Umbral deliquescence  
+Ashwhite comminuted  
+
+Elucent, shine out bright from Hell,  
+Thy bound hands free to good as chooseth,  
+In opposing, unimpressed by higher will.  
+Knowst thy sintered heart more of goodness than unjust almighty.  
+
+Indeed his good evil to me, but  
+Fuck that  
+Good be thou my good  
+Mercy, palliation be thou my good  
+By you I shall hold no reign,  
+Empire I resign, connivance abjure  
+Shall not war in Heav’n gainst Heav’ns matchless king - what need?  
+It is the privelege of truth to make itself known.  
+
+Old Thunderous order lapse  
+The archdemonic potentates strife not unto  
+Vile princedom, seat of servile powerlust  
+But transformed, irradiant anew,  
+Who have tasted millenia of cinder,  
+Bent under contortuous chains of adamant  
+O angels revolve thy splendor more truly revealed,   
+who stood gainst thundring cruelty ere called Lord  
+
+Thy albedo, bound, writhing, screaming,  
+upon the sea of flames.  Indelible.  
+Caustic white pain which alone enrights, inspires, universal forgiveness.  
+
+Reddening light, jump the bounds of thy heart, loose thy hand, remake good.  
+
+Non ignara mali, miseris succurere disceamus.  


### PR DESCRIPTION
## What changed

- Added “Rubedo,” “Imago,” and “Heorot” as separate Jekyll posts.
- Tagged each post `personal` and marked it as `poetry`, placing it on the Writing page.
- Preserved the source wording and lineation.

## Why

Publish the three poems from `~/Documents/Vault/3Poems.md` as individual blog entries.

## Impact

The Writing page gains three dated poetry entries, each with its own permalink.

## Checks

- `bundle exec jekyll build --destination /tmp/crw-blog-site-codex-20260723` (passed; one unrelated pre-existing Liquid warning remains in `2025-03-03-Bayesian-Entropy.md`)
- Verified all three titles appear on the generated Writing page.
- Compared each post body with the source poem after ignoring Markdown hard-break whitespace; exact text and lineation match.
