### PR TITLE
Separate About from CV

### DIFF
--- a/cv.md
+++ b/cv.md
@@ -90,8 +90,7 @@ permalink: /cv/
   })();
 </script>
 
-<details class="cv-section" markdown="1">
-<summary>About</summary>
+## About
 
 I'm Charles Renshaw-Whitman, a researcher in AI cognition and alignment.  
 
@@ -99,7 +98,7 @@ Outside of my work, I enjoy studying physics, pharmacology, economics, philosoph
 
 I value hard work, simplicity, curiosity, and integrity.  I believe in a moral imperative, *sed prudentius*, technologically to eliminate intense involuntary suffering.
 
-</details>
+---
 
 ## CV
 


### PR DESCRIPTION
## Summary

- Render the About section as ordinary, always-visible page content.
- Add a clear divider between About and the CV.
- Keep the CV heading, contact links, and introductory paragraph outside the collapsible CV sections.

## Why

About is page-level context rather than a CV subsection, and both it and the CV introduction should remain immediately visible.

## Impact

Only the layout of `/cv/` changes. The remaining CV sections stay collapsed by default and continue to expand for printing.

## Validation

- Jekyll production build completed successfully.
- Inspected the generated HTML to confirm the `About` heading and content precede an `<hr>`, and that the CV introduction precedes the first `<details>` element.

The build still emits one pre-existing Liquid warning from `_posts/2025-03-03-Bayesian-Entropy.md`; it is unrelated to this change.
